### PR TITLE
Correct link to the repository

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -52,4 +52,4 @@ or using ``conda``
    :caption: For contributors
 
    Whats New <whats-new>
-   GitHub repository <https://github.com/xarray-contrib/cf-xarray>
+   GitHub repository <https://github.com/larsbuntemeyer/xcmor/>


### PR DESCRIPTION
This was rather confusing about the documentation